### PR TITLE
[feat] 크리에이티브 검색 API 구현

### DIFF
--- a/notefolio/src/main/java/com/cdspseminar/notefolio/controller/CreativeController.java
+++ b/notefolio/src/main/java/com/cdspseminar/notefolio/controller/CreativeController.java
@@ -6,10 +6,7 @@ import com.cdspseminar.notefolio.dto.response.CreativesGetResponse;
 import com.cdspseminar.notefolio.service.CreativeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequestMapping("/creatives")
 @RequiredArgsConstructor
@@ -23,10 +20,15 @@ public class CreativeController {
         return ApiResponse.success(SuccessStatus.OK, response);
     }
 
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponse<?>> searchCreatives(@RequestParam String word) {
+        final CreativesGetResponse response = creativeService.searchCreatives(word);
+        return ApiResponse.success(SuccessStatus.OK, response);
+    }
+
 //    createAt, updateAt 잘되는지 테스트용으로 그냥 만들어봤어요 잘됩니다.
     @PostMapping
     public ResponseEntity<ApiResponse<?>> createCreatives() {
-
         creativeService.createCreative();
         return ApiResponse.success(SuccessStatus.CREATED);
     }

--- a/notefolio/src/main/java/com/cdspseminar/notefolio/controller/CreativeController.java
+++ b/notefolio/src/main/java/com/cdspseminar/notefolio/controller/CreativeController.java
@@ -1,0 +1,33 @@
+package com.cdspseminar.notefolio.controller;
+
+import com.cdspseminar.notefolio.common.ApiResponse;
+import com.cdspseminar.notefolio.common.SuccessStatus;
+import com.cdspseminar.notefolio.dto.response.CreativesGetResponse;
+import com.cdspseminar.notefolio.service.CreativeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/creatives")
+@RequiredArgsConstructor
+@RestController
+public class CreativeController {
+    private final CreativeService creativeService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<?>> getCreatives() {
+        final CreativesGetResponse response = creativeService.getCreatives();
+        return ApiResponse.success(SuccessStatus.OK, response);
+    }
+
+//    createAt, updateAt 잘되는지 테스트용으로 그냥 만들어봤어요 잘됩니다.
+    @PostMapping
+    public ResponseEntity<ApiResponse<?>> createCreatives() {
+
+        creativeService.createCreative();
+        return ApiResponse.success(SuccessStatus.CREATED);
+    }
+}

--- a/notefolio/src/main/java/com/cdspseminar/notefolio/domain/Creative.java
+++ b/notefolio/src/main/java/com/cdspseminar/notefolio/domain/Creative.java
@@ -1,5 +1,6 @@
 package com.cdspseminar.notefolio.domain;
 
+import com.cdspseminar.notefolio.domain.common.BaseTimeEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -11,7 +12,7 @@ import lombok.*;
 @Builder
 @Getter
 @Entity
-public class Creative {
+public class Creative extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/notefolio/src/main/java/com/cdspseminar/notefolio/domain/Creative.java
+++ b/notefolio/src/main/java/com/cdspseminar/notefolio/domain/Creative.java
@@ -1,10 +1,7 @@
 package com.cdspseminar.notefolio.domain;
 
 import com.cdspseminar.notefolio.domain.common.BaseTimeEntity;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.*;
 
 @NoArgsConstructor
@@ -20,4 +17,8 @@ public class Creative extends BaseTimeEntity {
     private Long view;
 
     private Long numLike;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "creator_id")
+    private Creator creator;
 }

--- a/notefolio/src/main/java/com/cdspseminar/notefolio/domain/Creative.java
+++ b/notefolio/src/main/java/com/cdspseminar/notefolio/domain/Creative.java
@@ -16,5 +16,7 @@ public class Creative {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String name;
+    private Long view;
+
+    private Long numLike;
 }

--- a/notefolio/src/main/java/com/cdspseminar/notefolio/domain/Creator.java
+++ b/notefolio/src/main/java/com/cdspseminar/notefolio/domain/Creator.java
@@ -19,7 +19,5 @@ public class Creator {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private Long view;
-
-    private Long numLike;
+    private String name;
 }

--- a/notefolio/src/main/java/com/cdspseminar/notefolio/dto/response/CreativeGetResponse.java
+++ b/notefolio/src/main/java/com/cdspseminar/notefolio/dto/response/CreativeGetResponse.java
@@ -1,0 +1,14 @@
+package com.cdspseminar.notefolio.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PROTECTED)
+public record CreativeGetResponse(
+        long creativeId,
+        long view,
+        long like
+) {
+
+
+}

--- a/notefolio/src/main/java/com/cdspseminar/notefolio/dto/response/CreativeGetResponse.java
+++ b/notefolio/src/main/java/com/cdspseminar/notefolio/dto/response/CreativeGetResponse.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 
 @Builder(access = AccessLevel.PROTECTED)
 public record CreativeGetResponse(
+        String name,
         long creativeId,
         long view,
         long like

--- a/notefolio/src/main/java/com/cdspseminar/notefolio/dto/response/CreativesGetResponse.java
+++ b/notefolio/src/main/java/com/cdspseminar/notefolio/dto/response/CreativesGetResponse.java
@@ -13,6 +13,7 @@ public record CreativesGetResponse(
     public static CreativesGetResponse of(List<Creative> creatives) {
         return CreativesGetResponse.builder().creatives(creatives.stream()
                .map(creative -> CreativeGetResponse.builder()
+                       .name(creative.getCreator().getName())
                        .creativeId(creative.getId())
                        .view(creative.getView())
                        .like(creative.getNumLike())

--- a/notefolio/src/main/java/com/cdspseminar/notefolio/dto/response/CreativesGetResponse.java
+++ b/notefolio/src/main/java/com/cdspseminar/notefolio/dto/response/CreativesGetResponse.java
@@ -1,0 +1,23 @@
+package com.cdspseminar.notefolio.dto.response;
+
+import com.cdspseminar.notefolio.domain.Creative;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record CreativesGetResponse(
+    List<CreativeGetResponse> creatives
+) {
+    public static CreativesGetResponse of(List<Creative> creatives) {
+        return CreativesGetResponse.builder().creatives(creatives.stream()
+               .map(creative -> CreativeGetResponse.builder()
+                       .creativeId(creative.getId())
+                       .view(creative.getView())
+                       .like(creative.getNumLike())
+                       .build())
+               .toList())
+               .build();
+    }
+}

--- a/notefolio/src/main/java/com/cdspseminar/notefolio/repository/CreativeRepository.java
+++ b/notefolio/src/main/java/com/cdspseminar/notefolio/repository/CreativeRepository.java
@@ -2,6 +2,12 @@ package com.cdspseminar.notefolio.repository;
 
 import com.cdspseminar.notefolio.domain.Creative;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface CreativeRepository extends JpaRepository<Creative, Long> {
+
+    @Query("SELECT c FROM Creative c WHERE c.creator.name LIKE %?1%")
+    List<Creative> findByCreatorNameContaining(String name);
 }

--- a/notefolio/src/main/java/com/cdspseminar/notefolio/repository/CreativeRepository.java
+++ b/notefolio/src/main/java/com/cdspseminar/notefolio/repository/CreativeRepository.java
@@ -1,0 +1,7 @@
+package com.cdspseminar.notefolio.repository;
+
+import com.cdspseminar.notefolio.domain.Creative;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CreativeRepository extends JpaRepository<Creative, Long> {
+}

--- a/notefolio/src/main/java/com/cdspseminar/notefolio/service/CreativeService.java
+++ b/notefolio/src/main/java/com/cdspseminar/notefolio/service/CreativeService.java
@@ -1,0 +1,28 @@
+package com.cdspseminar.notefolio.service;
+
+import com.cdspseminar.notefolio.domain.Creative;
+import com.cdspseminar.notefolio.dto.response.CreativesGetResponse;
+import com.cdspseminar.notefolio.repository.CreativeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CreativeService {
+    private final CreativeRepository creativeRepository;
+
+    public CreativesGetResponse getCreatives() {
+        List<Creative> creatives = creativeRepository.findAll();
+        return CreativesGetResponse.of(creatives);
+    }
+
+    @Transactional
+    public void createCreative(){
+        Creative creative = Creative.builder().view(3L).numLike(4L).build();
+        creativeRepository.save(creative);
+    }
+}

--- a/notefolio/src/main/java/com/cdspseminar/notefolio/service/CreativeService.java
+++ b/notefolio/src/main/java/com/cdspseminar/notefolio/service/CreativeService.java
@@ -20,6 +20,11 @@ public class CreativeService {
         return CreativesGetResponse.of(creatives);
     }
 
+    public CreativesGetResponse searchCreatives(String word) {
+        List<Creative> creatives = creativeRepository.findByCreatorNameContaining(word);
+        return CreativesGetResponse.of(creatives);
+    }
+
     @Transactional
     public void createCreative(){
         Creative creative = Creative.builder().view(3L).numLike(4L).build();


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #6 

## Key Changes 🔑
1. 크리에이티브 검색 API 구현
   - Creative의 creator 이름에 포함된 글자를 칠 경우, 연관된 creator의 Creative 들을 반환해준다.

![image](https://github.com/NOW-SOPT-CDSP-TEAM-WEB4/Notefolio-Server/assets/102401928/b620f7c7-0b0e-466f-a40d-7163f4dd38f7)

![image](https://github.com/NOW-SOPT-CDSP-TEAM-WEB4/Notefolio-Server/assets/102401928/4a86b408-5b48-43cf-99b7-9719eb296d12)


## To Reviewers 📢
-
