### PR TITLE
[feat] 크리에이티브 좋아요 취소 API 구현

### DIFF
--- a/notefolio/src/main/java/com/cdspseminar/notefolio/common/exception/ErrorStatus.java
+++ b/notefolio/src/main/java/com/cdspseminar/notefolio/common/exception/ErrorStatus.java
@@ -15,7 +15,9 @@ public enum ErrorStatus {
     CONFLICT(HttpStatus.CONFLICT, "이미 존재하는 리소스입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
     PROGRAMS_NOT_FOUND(HttpStatus.NOT_FOUND, "프로그램이 없습니다."),
-    CREATIVE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 크리에이티브 입니다.")
+    CREATIVE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 크리에이티브입니다."),
+    CREATOR_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 크리에이터입니다."),
+    HEART_NOT_FOUND(HttpStatus.NOT_FOUND, "좋아요하지 않은 크리에이티브입니다.") //추후 수정 예정...
     ;
 
     private final HttpStatus httpStatus;

--- a/notefolio/src/main/java/com/cdspseminar/notefolio/controller/HeartController.java
+++ b/notefolio/src/main/java/com/cdspseminar/notefolio/controller/HeartController.java
@@ -22,4 +22,13 @@ public class HeartController {
         heartService.createHeart(creatorId, heartCreateRequest);
         return ApiResponse.success(SuccessStatus.CREATED);
     }
+
+    @DeleteMapping("/{creativeId}")
+    public ResponseEntity<ApiResponse<?>> deleteHeart(
+            @RequestHeader Long creatorId,
+            @PathVariable Long creativeId
+    ){
+        heartService.deleteHeart(creatorId, creativeId);
+        return ApiResponse.success(SuccessStatus.OK);
+    }
 }

--- a/notefolio/src/main/java/com/cdspseminar/notefolio/repository/CreatorRepository.java
+++ b/notefolio/src/main/java/com/cdspseminar/notefolio/repository/CreatorRepository.java
@@ -1,0 +1,7 @@
+package com.cdspseminar.notefolio.repository;
+
+import com.cdspseminar.notefolio.domain.Creator;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CreatorRepository extends JpaRepository<Creator, Long> {
+}

--- a/notefolio/src/main/java/com/cdspseminar/notefolio/repository/HeartRepository.java
+++ b/notefolio/src/main/java/com/cdspseminar/notefolio/repository/HeartRepository.java
@@ -1,7 +1,10 @@
 package com.cdspseminar.notefolio.repository;
 
+import com.cdspseminar.notefolio.domain.Creative;
+import com.cdspseminar.notefolio.domain.Creator;
 import com.cdspseminar.notefolio.domain.Heart;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface HeartRepository extends JpaRepository<Heart, Long> {
+    Heart findByCreatorAndCreative(Creator creator, Creative creative);
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #8 

## Key Changes 🔑
1. 좋아요 취소 API 구현
2. 좋아요 취소 시 크리에이티브의 좋아요 개수 감소 메서드 추가
<img width="718" alt="스크린샷 2024-05-17 오후 7 39 04" src="https://github.com/NOW-SOPT-CDSP-TEAM-WEB4/Notefolio-Server/assets/91695537/85c4c9b3-a90b-423a-b3ce-bc5c4bd31f25">
<img width="640" alt="스크린샷 2024-05-17 오후 7 39 29" src="https://github.com/NOW-SOPT-CDSP-TEAM-WEB4/Notefolio-Server/assets/91695537/3cad8f8d-42b4-42e0-b004-f98de6b2fac2">

## To Reviewers 📢
- 마찬가지로 중복 좋아요 관련 검증 로직을 추가하지 않아서... 제가 솝커톤 끝나고 다음주 중으로 검증 로직 추가해놓겠습니다
